### PR TITLE
Improve path parsing

### DIFF
--- a/src/kompose.js
+++ b/src/kompose.js
@@ -29,7 +29,10 @@
     if (typeof path === 'object') {
       return path;
     }
-    path = (path || '').replace(/\.?\[(\d+)]/g, '.$1');
+    path = (path || '').
+      replace(/\[(\d+)]/g, '.$1'). // remove braces and ensure period before indexes
+      replace(/\.+/g, '.'). // reduce multiple periods to single
+      replace(/(^\.|\.$)/g, ''); // trim left/right periods
     return path.split('.');
   }
 

--- a/test/kompose-test.js
+++ b/test/kompose-test.js
@@ -43,6 +43,13 @@ test('kp.get', function get(t) {
   t.same(kp.get(obj, 'a.toString.name'), 'toString',
     'it returns value at path for language level objects');
 
+  var obj2 = [{ a: ko.observableArray(['foo', 'bar'])}];
+  t.same(kp.get(obj2, '[0].a.[1]'), 'bar',
+    'it correctly parses array paths at beginning and end of path');
+
+  t.same(kp.get(obj, '.b....c..0..'), 2,
+    'it ignores excess periods');
+
   t.end();
 });
 


### PR DESCRIPTION
- array paths at beginning and end of paths now work.
- ignores excess periods.

fixes #5 
